### PR TITLE
Add migration for configuration and additional configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,19 @@ utilsBundle.ajax.post(url, data, config);
 Following configuration parameter can be overridden:
 
 ```yaml
+# Default configuration for extension with alias: "huh_utils"
 huh_utils:
-    tmp_folder: 'files/tmp/huh_utils_bundle'
+  tmp_folder:           files/tmp/huh_utils_bundle
+
+  # Default folder where to store pdf preview images.
+  pdfPreviewFolder:     null
+  cache:
+
+    # Enable database tree cache is generated on cache warmup.
+    enable_generate_database_tree_cache: false
+
+  # Load utils bundle assets. Default value will be changed to false in next major version.
+  enable_load_assets:   true
 ```
 
 ## Twig Extensions

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,17 @@
+# Upgrade notices
+
+## Prepare your bundle for utils bundle v3
+
+Following steps could be done to prepare your bundle for utils bundle version 3 and make a smooth transition supporting v2 and v3.
+
+* Bundle class renamed
+    - HeimrichHannotContaoUtilsBundle renamed to HeimrichHannotUtilsBundle
+    - min. bundle version: 2.187.0
+* Bundle alias renamed 
+    - alias renamed from utils_bundle to huh_utils
+    - change configuration key utils_bundle to huh_utils
+    - min. bundle version: 2.187.0
+* Loading assets disabled by default
+    - default value for huh_utils.enable_load_assets changed from true to false
+    - set to true in your configuration to ensure assets are still added in v3
+    

--- a/src/Cache/UtilCacheWarmer.php
+++ b/src/Cache/UtilCacheWarmer.php
@@ -24,21 +24,6 @@ class UtilCacheWarmer implements CacheWarmerInterface
     private $filesystem;
 
     /**
-     * @var ResourceFinderInterface
-     */
-    private $finder;
-
-    /**
-     * @var FileLocator
-     */
-    private $locator;
-
-    /**
-     * @var string
-     */
-    private $rootDir;
-
-    /**
      * @var Connection
      */
     private $connection;
@@ -61,9 +46,6 @@ class UtilCacheWarmer implements CacheWarmerInterface
     public function __construct(Filesystem $filesystem, ResourceFinderInterface $finder, FileLocator $locator, $rootDir, Connection $connection, TemplateUtil $templateUtil, ContaoFrameworkInterface $framework)
     {
         $this->filesystem = $filesystem;
-        $this->finder = $finder;
-        $this->locator = $locator;
-        $this->rootDir = $rootDir;
         $this->connection = $connection;
         $this->templateUtil = $templateUtil;
         $this->framework = $framework;

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -14,6 +14,7 @@ use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use HeimrichHannot\UtilsBundle\HeimrichHannotContaoUtilsBundle;
+use HeimrichHannot\UtilsBundle\HeimrichHannotUtilsBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class Plugin implements BundlePluginInterface, ConfigPluginInterface
@@ -26,6 +27,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface
         return [
             BundleConfig::create(HeimrichHannotContaoUtilsBundle::class)
                 ->setLoadAfter([ContaoCoreBundle::class]),
+            BundleConfig::create(HeimrichHannotUtilsBundle::class)->setLoadAfter([
+                ContaoCoreBundle::class,
+                HeimrichHannotContaoUtilsBundle::class,
+            ]),
         ];
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,6 +26,12 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()
             ->scalarNode('tmp_folder')->defaultValue('files/tmp/huh_utils_bundle')->end()
             ->scalarNode('pdfPreviewFolder')->defaultNull()->info('Default folder where to store pdf preview images.')->end()
+            ->arrayNode('cache')
+                ->children()
+                    ->booleanNode('enable_generate_database_tree_cache')->defaultFalse()->info('Enable database tree cache is generated on cache warmup.')->end()
+                ->end()
+            ->end()
+            ->booleanNode('enable_load_assets')->defaultTrue()->info('Load utils bundle assets. Default value will be changed to false in next major version.')->end()
         ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/HeimrichHannotUtilsExtension.php
+++ b/src/DependencyInjection/HeimrichHannotUtilsExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\UtilsBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class HeimrichHannotUtilsExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        /* @todo Remove this passage in version 3.0 */
+        if (!isset($config['pdfPreviewFolder'])) {
+            $config['pdfPreviewFolder'] = $container->getParameter('huh.utils.filecache.folder').\DIRECTORY_SEPARATOR.'pdfPreview';
+        }
+
+        $container->setParameter('huh_utils', $config);
+    }
+
+    public function getAlias()
+    {
+        return 'huh_utils';
+    }
+}

--- a/src/DependencyInjection/UtilsBundleExtension.php
+++ b/src/DependencyInjection/UtilsBundleExtension.php
@@ -10,8 +10,9 @@ namespace HeimrichHannot\UtilsBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
-class UtilsBundleExtension extends Extension
+class UtilsBundleExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * Loads a specific configuration.
@@ -20,14 +21,12 @@ class UtilsBundleExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
+    }
 
-        /* @todo Remove this passage in version 3.0 */
-        if (!isset($config['pdfPreviewFolder'])) {
-            $config['pdfPreviewFolder'] = $container->getParameter('huh.utils.filecache.folder').\DIRECTORY_SEPARATOR.'pdfPreview';
-        }
-
-        $container->setParameter('huh_utils', $config);
+    public function prepend(ContainerBuilder $container)
+    {
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $configs);
+        $container->prependExtensionConfig('huh_utils', $config);
     }
 }

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\UtilsBundle\EventListener;
+
+use HeimrichHannot\UtilsBundle\Container\ContainerUtil;
+
+/**
+ * @Hook("initializeSystem")
+ */
+class InitializeSystemListener
+{
+    /**
+     * @var ContainerUtil
+     */
+    protected $containerUtil;
+    /**
+     * @var array
+     */
+    protected $bundleConfig;
+
+    /**
+     * InitializeSystemListener constructor.
+     */
+    public function __construct(ContainerUtil $containerUtil, array $bundleConfig)
+    {
+        $this->containerUtil = $containerUtil;
+        $this->bundleConfig = $bundleConfig;
+    }
+
+    public function __invoke(): void
+    {
+        if ($this->containerUtil->isBackend()) {
+            $GLOBALS['TL_CSS']['utils-bundle'] = 'bundles/heimrichhannotcontaoutils/css/contao-utils-bundle.be.css|static';
+        }
+
+        if (isset($this->bundleConfig['enable_load_assets']) && true === $this->bundleConfig['enable_load_assets']) {
+            array_insert($GLOBALS['TL_JAVASCRIPT'], 1, [
+                'contao-utils-bundle' => 'bundles/heimrichhannotcontaoutils/js/contao-utils-bundle.js|static',
+            ]);
+        }
+    }
+}

--- a/src/HeimrichHannotUtilsBundle.php
+++ b/src/HeimrichHannotUtilsBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\UtilsBundle;
+
+use HeimrichHannot\UtilsBundle\DependencyInjection\HeimrichHannotUtilsExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class HeimrichHannotUtilsBundle extends Bundle
+{
+    public function getContainerExtension()
+    {
+        return new HeimrichHannotUtilsExtension();
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -1,9 +1,16 @@
 services:
+  _defaults:
+    autowire: true
+    bind:
+      $bundleConfig: '%huh_utils%'
+
+  HeimrichHannot\UtilsBundle\EventListener\:
+    resource: '../../EventListener/*'
+    public: true
+
   huh.utils.listener.insert_tags:
     class: HeimrichHannot\UtilsBundle\EventListener\InsertTagsListener
     public: true
-    autowire: true
   huh.utils.listener.frontend_page:
     class: HeimrichHannot\UtilsBundle\EventListener\FrontendPageListener
     public: true
-    autowire: true

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -6,6 +6,9 @@
  * @license LGPL-3.0-or-later
  */
 
+/*
+ * Models
+ */
 $GLOBALS['TL_MODELS']['tl_cfg_tag'] = 'HeimrichHannot\UtilsBundle\Model\CfgTagModel';
 
 /*

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,32 +1,19 @@
 <?php
 
-/**
- * JS
- */
-array_insert(
-    $GLOBALS['TL_JAVASCRIPT'],
-    1,
-    [
-        'contao-utils-bundle' => 'bundles/heimrichhannotcontaoutils/js/contao-utils-bundle.js|static'
-    ]
-);
-
 /*
- * Assets
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
  */
-if (System::getContainer()->get('huh.utils.container')->isBackend()) {
-    $GLOBALS['TL_CSS']['utils-bundle'] = 'bundles/heimrichhannotcontaoutils/css/contao-utils-bundle.be.css|static';
-}
 
-/**
- * Models
- */
 $GLOBALS['TL_MODELS']['tl_cfg_tag'] = 'HeimrichHannot\UtilsBundle\Model\CfgTagModel';
 
-/**
+/*
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['replaceInsertTags']['huh.utils.listener.insert_tags']    = ['huh.utils.listener.insert_tags', 'onReplaceInsertTags'];
-$GLOBALS['TL_HOOKS']['initializeSystem']['huh.utils.template']                 = ['huh.utils.template', 'getAllTemplates'];
-$GLOBALS['TL_HOOKS']['loadDataContainer']['huh.utils.tree_cache']              = ['huh.utils.cache.database_tree', 'loadDataContainer'];
+$GLOBALS['TL_HOOKS']['replaceInsertTags']['huh.utils.listener.insert_tags'] = ['huh.utils.listener.insert_tags', 'onReplaceInsertTags'];
+$GLOBALS['TL_HOOKS']['initializeSystem']['huh.utils.template'] = ['huh.utils.template', 'getAllTemplates'];
+$GLOBALS['TL_HOOKS']['loadDataContainer']['huh.utils.tree_cache'] = ['huh.utils.cache.database_tree', 'loadDataContainer'];
 $GLOBALS['TL_HOOKS']['modifyFrontendPage']['huh.utils.listener.frontend_page'] = ['huh.utils.listener.frontend_page', 'modifyFrontendPage'];
+
+$GLOBALS['TL_HOOKS']['initializeSystem']['huh_utils'] = [\HeimrichHannot\UtilsBundle\EventListener\InitializeSystemListener::class, '__invoke'];


### PR DESCRIPTION
This PR has following content:
- update bundle infrastructure in preparation of verions 3.0 while keeping existing namespaces and names
- add option to disable loading of assets
- add option to enable database tree cache on cache:warmup

See:
- https://github.com/heimrichhannot/contao-categories-bundle/issues/10
- #13 

ToDo:
- [x] check for side effects
- [x] Update readme
- [x] restore model comments