### PR TITLE
Rewrite AccordionUtil::structureAccordionStartStop() to support nested accordions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -43,7 +43,7 @@
             <directory>./src</directory>
             <exclude>
                 <directory>./src/Resources</directory>
-                <file>src/Util/Utils.php</file>
+                <file>src/Util/AbstractServiceSubscriber.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Accordion/AccordionUtil.php
+++ b/src/Accordion/AccordionUtil.php
@@ -134,6 +134,9 @@ class AccordionUtil
      *
      * @param array  $data   Data describing the accordion. Usually this is taken from \Contao\Template::getData().
      * @param string $prefix The prefix for the flags
+     *
+     * @deprecated Use Utils service instead
+     * @codeCoverageIgnore
      */
     public function structureAccordionStartStop(array &$data, string $prefix = 'accordion_')
     {

--- a/src/Util/AbstractServiceSubscriber.php
+++ b/src/Util/AbstractServiceSubscriber.php
@@ -8,9 +8,6 @@
 
 namespace HeimrichHannot\UtilsBundle\Util;
 
-/**
- * @codeCoverageIgnore
- */
 if (interface_exists('Symfony\Component\DependencyInjection\ServiceSubscriberInterface')) {
     abstract class AbstractServiceSubscriber implements \Symfony\Component\DependencyInjection\ServiceSubscriberInterface
     {

--- a/src/Util/Ui/AccordionUtil.php
+++ b/src/Util/Ui/AccordionUtil.php
@@ -6,7 +6,10 @@ use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
 
 class AccordionUtil
 {
-    private ModelUtil $modelUtil;
+    /**
+     * @var ModelUtil 
+     */
+    private $modelUtil;
 
     public function __construct(ModelUtil $modelUtil)
     {

--- a/src/Util/Ui/AccordionUtil.php
+++ b/src/Util/Ui/AccordionUtil.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace HeimrichHannot\UtilsBundle\Util\Ui;
+
+use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
+
+class AccordionUtil
+{
+    private ModelUtil $modelUtil;
+
+    public function __construct(ModelUtil $modelUtil)
+    {
+        $this->modelUtil = $modelUtil;
+    }
+
+    public function structureAccordionStartStop(array &$data, string $prefix = 'accordion_'): void
+    {
+        if (!isset($data['id']) || !isset($data['pid']) || !isset($data['ptable'])) {
+            return;
+        }
+
+        $cacheKey = $data['ptable'].'_'.$data['pid'];
+
+        if (!isset($this->accordionStartStopCache[$cacheKey])) {
+            if (null !== ($elements = $this->modelUtil->findModelInstancesBy (
+                    'tl_content',
+                    ['tl_content.ptable=?', 'tl_content.pid=?', 'tl_content.invisible!=1',],
+                    [$data['ptable'], $data['pid'],],
+                    ['order' => 'sorting ASC',]
+                ))) {
+                $this->accordionStartStopCache[$cacheKey] = $this->generateAccordionLevel($elements->getModels());
+            }
+        }
+
+        if (isset($this->accordionStartStopCache[$cacheKey][$data['id']])) {
+            $data[$prefix.'parentId'] = $this->accordionStartStopCache[$cacheKey][$data['id']]['parent'];
+            $data[$prefix.'first'] = $this->accordionStartStopCache[$cacheKey][$data['id']]['first'] ?? false;
+            $data[$prefix.'last'] = $this->accordionStartStopCache[$cacheKey][$data['id']]['last'] ?? false;
+        } else {
+            return;
+        }
+    }
+
+    private function generateAccordionLevel(array $elements, int &$index = 0, int $level = 0): array
+    {
+        $flatAccordionList = [];
+        $open = false;
+        $startElement = null;
+        $lastStopElement = null;
+        for ($index; $index < count($elements); $index++) {
+            $element = $elements[$index];
+            if ('accordionStart' === $element->type) {
+                if ($open) {
+                    $flatAccordionList = $flatAccordionList + $this->generateAccordionLevel($elements, $index, ($level + 1));
+                } else {
+                    $flatAccordionList[$element->id] = [
+                        'type' => $element->type,
+                        'level' => $level,
+                    ];
+                    if (!$startElement) {
+                        $flatAccordionList[$element->id]['parent'] = $element->id;
+                        $startElement                              = $element;
+                        $flatAccordionList[$element->id]['first']  = true;
+                    } else {
+                        $flatAccordionList[$element->id]['parent'] = $startElement->id;
+                    }
+                    $open = true;
+                }
+            } elseif ('accordionStop' === $element->type) {
+                if (!$open && $level !== 0) {
+                    if ($lastStopElement) {
+                        $flatAccordionList[$lastStopElement->id]['last'] = true;
+                    }
+                    $index--;
+                    return $flatAccordionList;
+                }
+                if ($open && $level !== 0) {
+                    $lastStopElement = $element;
+                }
+
+                $open = false;
+                $flatAccordionList[$element->id] = [
+                    'parent' => $startElement->id,
+                    'type' => $element->type,
+                    'level' => $level,
+                ];
+                if ($index === (count($elements) - 1) || !in_array($elements[($index + 1)]->type, ['accordionStart', 'accordionStop'])) {
+                    $flatAccordionList[$element->id]['last'] = true;
+                    $startElement = null;
+                }
+            }
+        }
+        return $flatAccordionList;
+    }
+}

--- a/src/Util/Ui/AccordionUtil.php
+++ b/src/Util/Ui/AccordionUtil.php
@@ -7,7 +7,7 @@ use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
 class AccordionUtil
 {
     /**
-     * @var ModelUtil 
+     * @var ModelUtil
      */
     private $modelUtil;
 

--- a/src/Util/Ui/AccordionUtil.php
+++ b/src/Util/Ui/AccordionUtil.php
@@ -87,7 +87,7 @@ class AccordionUtil
                     'type' => $element->type,
                     'level' => $level,
                 ];
-                if ($index === (count($elements) - 1) || !in_array($elements[($index + 1)]->type, ['accordionStart', 'accordionStop'])) {
+                if ($index === (count($elements) - 1) || ($level < 1 && !in_array($elements[($index + 1)]->type, ['accordionStart', 'accordionStop']))) {
                     $flatAccordionList[$element->id]['last'] = true;
                     $startElement = null;
                 }

--- a/src/Util/Utils.php
+++ b/src/Util/Utils.php
@@ -13,6 +13,7 @@ use HeimrichHannot\UtilsBundle\Util\Locale\LocaleUtil;
 use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
 use HeimrichHannot\UtilsBundle\Util\Request\RequestUtil;
 use HeimrichHannot\UtilsBundle\Util\String\StringUtil;
+use HeimrichHannot\UtilsBundle\Util\Ui\AccordionUtil;
 use HeimrichHannot\UtilsBundle\Util\User\UserUtil;
 use Psr\Container\ContainerInterface;
 
@@ -31,10 +32,16 @@ class Utils extends AbstractServiceSubscriber
         $this->locator = $locator;
     }
 
+    public function accordion(): AccordionUtil
+    {
+        return $this->locator->get(AccordionUtil::class);
+    }
+
     public function array(): ArrayUtil
     {
         return $this->locator->get(ArrayUtil::class);
     }
+
     public function container(): ContainerUtil
     {
         return $this->locator->get(ContainerUtil::class);
@@ -68,6 +75,7 @@ class Utils extends AbstractServiceSubscriber
     public static function getSubscribedServices()
     {
         return [
+            AccordionUtil::class,
             ArrayUtil::class,
             ContainerUtil::class,
             LocaleUtil::class,

--- a/tests/Util/Ui/AccordionUtilTest.php
+++ b/tests/Util/Ui/AccordionUtilTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace HeimrichHannot\UtilsBundle\Tests\Util\Ui;
+
+use Contao\ContentModel;
+use Contao\Model\Collection;
+use HeimrichHannot\TestUtilitiesBundle\Mock\ModelMockTrait;
+use HeimrichHannot\UtilsBundle\Tests\AbstractUtilsTestCase;
+use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
+use HeimrichHannot\UtilsBundle\Util\Ui\AccordionUtil;
+use PHPUnit\Framework\MockObject\MockBuilder;
+
+class AccordionUtilTest extends AbstractUtilsTestCase
+{
+    use ModelMockTrait;
+
+    public function getTestInstance(array $parameters = [], ?MockBuilder $mockBuilder = null)
+    {
+        $modelUtil = $parameters['modelUtil'] ?? $this->createMock(ModelUtil::class);
+
+        return new AccordionUtil($modelUtil);
+    }
+
+    public function structureAccordionStartStopProvider()
+    {
+        return [
+            // Empty (pid=1)
+            '1_1' => [[], null],
+            '1_2' => [['id' => 1, 'pid' => 1], null],
+            '1_3' => [['id' => 1, 'pid' => 1, 'ptable' => 'tl_article'], null],
+            // Simple (pid=2)
+            '2_1' => [['id' => 1, 'pid' => 2, 'ptable' => 'tl_content'], false, 1, true, false],
+            '2_2' => [['id' => 2, 'pid' => 2, 'ptable' => 'tl_content'], false, false, null, null],
+            '2_3' => [['id' => 3, 'pid' => 2, 'ptable' => 'tl_content'], false, 1, false, true],
+            // Simple (pid=3)
+            '3_1' => [['id' => 1, 'pid' => 3, 'ptable' => 'tl_content'], false, 1,     true,  false],
+            '3_2' => [['id' => 2, 'pid' => 3, 'ptable' => 'tl_content'], false, false, null,  null],
+            '3_3' => [['id' => 3, 'pid' => 3, 'ptable' => 'tl_content'], false, 1,     false, true],
+            '3_4' => [['id' => 4, 'pid' => 3, 'ptable' => 'tl_content'], false, false, null,  null],
+            '3_5' => [['id' => 5, 'pid' => 3, 'ptable' => 'tl_content'], false, 5,     true,  false],
+            '3_6' => [['id' => 6, 'pid' => 3, 'ptable' => 'tl_content'], false, false, null,  null],
+            '3_7' => [['id' => 7, 'pid' => 3, 'ptable' => 'tl_content'], false, 5,     false, true],
+            // PID = 4
+            '4_1' => [['id' => 1, 'pid' => 4, 'ptable' => 'tl_content'], false, 1,     true,  false],
+            '4_2' => [['id' => 2, 'pid' => 4, 'ptable' => 'tl_content'], false, false, null,  null],
+            '4_3' => [['id' => 3, 'pid' => 4, 'ptable' => 'tl_content'], false, 1,     false, false],
+            '4_5' => [['id' => 5, 'pid' => 4, 'ptable' => 'tl_content'], false, 1,     false, false],
+            '4_6' => [['id' => 6, 'pid' => 4, 'ptable' => 'tl_content'], false, false, null,  null],
+            '4_7' => [['id' => 7, 'pid' => 4, 'ptable' => 'tl_content'], false, 1,     false,  true],
+            // PID = 5
+            '5_1'  => [['id' => 1,  'pid' => 5, 'ptable' => 'tl_content'], false, 1,     true,  false],
+            '5_2'  => [['id' => 2,  'pid' => 5, 'ptable' => 'tl_content'], false, false, null,  null],
+            '5_8'  => [['id' => 8,  'pid' => 5, 'ptable' => 'tl_content'], false, 8,     true, false],
+            '5_9'  => [['id' => 9,  'pid' => 5, 'ptable' => 'tl_content'], false, false, null, null],
+            '5_10' => [['id' => 10, 'pid' => 5, 'ptable' => 'tl_content'], false, 8,     false, true],
+            '5_3'  => [['id' => 3,  'pid' => 5, 'ptable' => 'tl_content'], false, 1,     false,  true],
+            '5_4'  => [['id' => 4,  'pid' => 5, 'ptable' => 'tl_content'], false, false,  null,  null],
+            // PID = 6
+            '6_1'  => [['id' => 1,  'pid' => 6, 'ptable' => 'tl_content'], false, 1,     true,  false],
+            '6_2'  => [['id' => 2,  'pid' => 6, 'ptable' => 'tl_content'], false, false, null,  null],
+            '6_8'  => [['id' => 8,  'pid' => 6, 'ptable' => 'tl_content'], false, 8,     true, false],
+            '6_9'  => [['id' => 9,  'pid' => 6, 'ptable' => 'tl_content'], false, false, null, null],
+            '6_10' => [['id' => 10, 'pid' => 6, 'ptable' => 'tl_content'], false, 8,     false, true],
+            '6_3'  => [['id' => 3,  'pid' => 6, 'ptable' => 'tl_content'], false, 1,     false,  true],
+            '6_4'  => [['id' => 4,  'pid' => 6, 'ptable' => 'tl_content'], false, false,  null,  null],
+            // PID = 7
+            '7_1'  => [['id' => 1,  'pid' => 7, 'ptable' => 'tl_content'], false, 1,     true,  false],
+            '7_2'  => [['id' => 2,  'pid' => 7, 'ptable' => 'tl_content'], false, false, null,  null],
+            '7_8'  => [['id' => 8,  'pid' => 7, 'ptable' => 'tl_content'], false, 8,     true,  false],
+            '7_9'  => [['id' => 9,  'pid' => 7, 'ptable' => 'tl_content'], false, false, null,  null],
+            '7_10' => [['id' => 10, 'pid' => 7, 'ptable' => 'tl_content'], false, 8,     false, false],
+            '7_12' => [['id' => 12, 'pid' => 7, 'ptable' => 'tl_content'], false, 8,     false, false],
+            '7_13' => [['id' => 13, 'pid' => 7, 'ptable' => 'tl_content'], false, false, null,  null],
+            '7_14' => [['id' => 14, 'pid' => 7, 'ptable' => 'tl_content'], false, 8,     false, true],
+            '7_11' => [['id' => 11, 'pid' => 7, 'ptable' => 'tl_content'], false, false, null,  null],
+            '7_3'  => [['id' => 3,  'pid' => 7, 'ptable' => 'tl_content'], false, 1,     false,  true],
+            '7_4'  => [['id' => 4,  'pid' => 7, 'ptable' => 'tl_content'], false, false,  null,  null],
+        ];
+    }
+
+    /**
+     * @dataProvider structureAccordionStartStopProvider
+     */
+    public function testStructureAccordionStartStop($data, $same = false, $parent = false, $first = null, $last = null)
+    {
+        $modelUtil = $this->createMock(ModelUtil::class);
+        $modelUtil->method('findModelInstancesBy')->willReturnCallback(function (string $table, array $columns, array $values, array $options = []) {
+            $pid = $values[1];
+
+            switch ($pid) {
+                case 1: return null;
+                case 2:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+                case 3:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 4, 'type' => 'headline']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 5, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 6, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 7, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+                case 4:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 5, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 6, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 7, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+                case 5:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 8, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 9, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 10, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 4, 'type' => 'headline']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 5, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 6, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 7, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+                case 6:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 8, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 9, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 10, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 11, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 4, 'type' => 'headline']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 5, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 6, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 7, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+                case 7:
+                    return new Collection([
+                        $this->mockModelObject(ContentModel::class, ['id' => 1, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 2, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 8, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 9, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 10, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 12, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 13, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 14, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 11, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 3, 'type' => 'accordionStop']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 4, 'type' => 'headline']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 5, 'type' => 'accordionStart']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 6, 'type' => 'text']),
+                        $this->mockModelObject(ContentModel::class, ['id' => 7, 'type' => 'accordionStop']),
+                    ], 'tl_content');
+            }
+        });
+
+        $instance = $this->getTestInstance(['modelUtil' => $modelUtil]);
+
+        if ($same !== false) {
+            if (null === $same) {
+                $same = $data;
+            }
+        }
+
+        $instance->structureAccordionStartStop($data);
+
+        if ($same !== false) {
+            $this->assertSame($data, $same);
+        }
+
+        if ($parent !== false) {
+            $this->assertSame($parent, $data['accordion_parentId']);
+        }
+
+        if ($first !== null) {
+            $this->assertSame($first, $data['accordion_first']);
+        } else {
+            $this->assertArrayNotHasKey('accordion_first', $data);
+        }
+        if ($last !== null) {
+            $this->assertSame($last, $data['accordion_last']);
+        } else {
+            $this->assertArrayNotHasKey('accordion_last', $data);
+        }
+    }
+}

--- a/tests/Util/UtilsTest.php
+++ b/tests/Util/UtilsTest.php
@@ -15,6 +15,7 @@ use HeimrichHannot\UtilsBundle\Util\Locale\LocaleUtil;
 use HeimrichHannot\UtilsBundle\Util\Model\ModelUtil;
 use HeimrichHannot\UtilsBundle\Util\Request\RequestUtil;
 use HeimrichHannot\UtilsBundle\Util\String\StringUtil;
+use HeimrichHannot\UtilsBundle\Util\Ui\AccordionUtil;
 use HeimrichHannot\UtilsBundle\Util\User\UserUtil;
 use HeimrichHannot\UtilsBundle\Util\Utils;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -27,6 +28,9 @@ class UtilsTest extends ContaoTestCase
             $parameter['locator'] = $this->createMock(ServiceLocator::class);
             $parameter['locator']->method('get')->willReturnCallback(function ($id) {
                 switch ($id) {
+                    case AccordionUtil::class:
+                        return $this->createMock(AccordionUtil::class);
+
                     case ArrayUtil::class:
                         return $this->createMock(ArrayUtil::class);
 
@@ -54,6 +58,11 @@ class UtilsTest extends ContaoTestCase
         }
 
         return new Utils($parameter['locator']);
+    }
+
+    public function testAccordion()
+    {
+        $this->assertInstanceOf(AccordionUtil::class, $this->getTestInstance()->accordion());
     }
 
     public function testArray()


### PR DESCRIPTION
This PR rewrites the the AccordionUtil::structureAccordionStartStop() method to support nested accordions. The new method is put into the utils namespace.