### PR TITLE
Fix a potential error upon cache warmup and a missing system/tmp folder

### DIFF
--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -40,7 +40,7 @@ $fields = [
     ],
 ];
 
-if (!\Contao\Config::get('dbCacheMaxTime')) {
+if (!\Contao\Config::get('dbCacheMaxTime') && is_dir(TL_ROOT . '/system/tmp/')) {
     \Contao\Config::set('dbCacheMaxTime', serialize(\HeimrichHannot\UtilsBundle\Cache\DatabaseCacheUtil::DEFAULT_MAX_CACHE_TIME));
     \Contao\Config::persist('dbCacheMaxTime', serialize(\HeimrichHannot\UtilsBundle\Cache\DatabaseCacheUtil::DEFAULT_MAX_CACHE_TIME));
 }


### PR DESCRIPTION
If there is no `system/tmp` folder available and you try to warmup the cache, it will result in an error. This PR should fix that.

Ideally, this logic should be changed to not use Contao local config, but rather some service like `DatabaseCacheUtil::getDbCacheMaxTime()` which checks if local config value exists, otherwise returns a default value.