### PR TITLE
Refactor Patchwork\Utf8 to UnicodeString

### DIFF
--- a/src/File/FileUtil.php
+++ b/src/File/FileUtil.php
@@ -23,6 +23,7 @@ use Ghostscript\Transcoder;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\String\UnicodeString;
 
 class FileUtil
 {
@@ -289,7 +290,7 @@ class FileUtil
 
         $name = $file->filename;
 
-        $name = \Patchwork\Utf8::toAscii(StringUtil::standardize($name, $preserveUppercase), '');
+        $name = (new UnicodeString(StringUtil::standardize($name, $preserveUppercase)))->ascii()->toString();
 
         if ('id-' != $name && !$this->container->get('huh.utils.string')->startsWith($fileName, 'id-')) {
             $name = preg_replace('/^(id-)/', '', $name);


### PR DESCRIPTION
I found the code by accident while looking for all the places with `\Patchwork\Utf8` in a customer project.
I'm not entirely sure about the correct refactoring of the second parameter (empty substring) of the previous `Utf8::toAscii` - maybe someone can test the correct behavior or do we have to add some rules to `->ascii()`, don't we?

At the moment the code could fail if `patchwork/utf8` is not installed - because it's no requirement of this extension!
