### PR TITLE
Fix Controller replaceInsertTags removed in Contao 5

### DIFF
--- a/phpunit.xml.dist.bak
+++ b/phpunit.xml.dist.bak
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         backupGlobals="false"
         backupStaticAttributes="false"
@@ -11,16 +12,7 @@
         convertWarningsToExceptions="true"
         processIsolation="false"
         stopOnFailure="false"
->
-    <coverage>
-        <include>
-            <directory>./src</directory>
-        </include>
-        <exclude>
-            <directory>./src/Resources</directory>
-            <file>src/Util/AbstractServiceSubscriber.php</file>
-        </exclude>
-    </coverage>
+    >
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="display_errors" value="1"/>
@@ -28,8 +20,9 @@
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
         <ini name="xdebug.mode" value="coverage"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
+
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>./tests/</directory>
@@ -44,6 +37,17 @@
             <exclude>tests/Security</exclude>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+            <exclude>
+                <directory>./src/Resources</directory>
+                <file>src/Util/AbstractServiceSubscriber.php</file>
+            </exclude>
+        </whitelist>
+    </filter>
+
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>

--- a/src/Util/ContainerUtil.php
+++ b/src/Util/ContainerUtil.php
@@ -173,7 +173,7 @@ class ContainerUtil extends AbstractServiceSubscriber
                 && $this->framework->getAdapter(Input::class)->cookie('FE_PREVIEW');
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [
             'monolog.logger.contao' => LoggerInterface::class,

--- a/src/Util/ModelUtil.php
+++ b/src/Util/ModelUtil.php
@@ -11,6 +11,7 @@ namespace HeimrichHannot\UtilsBundle\Util;
 use Contao\Controller;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\Date;
 use Contao\Model;
 use Contao\Model\Collection;
@@ -18,7 +19,8 @@ use Contao\Model\Collection;
 class ModelUtil
 {
     public function __construct(
-        private ContaoFramework $framework
+        private ContaoFramework $framework,
+        private InsertTagParser $insertTagParser
     )
     {
     }
@@ -95,8 +97,8 @@ class ModelUtil
             return null;
         }
 
-        if (\is_array($values) && true !== $options['skipReplaceInsertTags']) {
-            $values = array_map([$this->framework->getAdapter(Controller::class), 'replaceInsertTags'], $values);
+        if (is_array($values) && !$options['skipReplaceInsertTags']) {
+            $values = array_map(fn($value) => $this->insertTagParser->replace($value), $values);
         }
 
         if (empty($columns)) {
@@ -155,8 +157,8 @@ class ModelUtil
             return null;
         }
 
-        if (\is_array($values) && !$options['skipReplaceInsertTags']) {
-            $values = array_map([$this->framework->getAdapter(Controller::class), 'replaceInsertTags'], $values);
+        if (is_array($values) && !$options['skipReplaceInsertTags']) {
+            $values = array_map(fn($value) => $this->insertTagParser->replace($value), $values);
         }
 
         if (empty($columns)) {

--- a/src/Util/Utils.php
+++ b/src/Util/Utils.php
@@ -26,7 +26,7 @@ class Utils extends AbstractServiceSubscriber
     /**
      * @var ContainerInterface
      */
-    protected $locator;
+    protected ContainerInterface $locator;
 
     /**
      * Utils constructor.
@@ -116,7 +116,7 @@ class Utils extends AbstractServiceSubscriber
         return $this->locator->get(UserUtil::class);
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [
             AccordionUtil::class,

--- a/tests/Util/ModelUtilTest.php
+++ b/tests/Util/ModelUtilTest.php
@@ -11,6 +11,7 @@ namespace HeimrichHannot\UtilsBundle\Tests\Util;
 use Contao\ContentModel;
 use Contao\Controller;
 use Contao\CoreBundle\Framework\Adapter;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\Model;
 use Contao\PageModel;
 use Contao\System;
@@ -22,7 +23,6 @@ use HeimrichHannot\UtilsBundle\Tests\Util\Model\CfgTagModel;
 use HeimrichHannot\UtilsBundle\Util\ModelUtil;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
-use function Clue\StreamFilter\fun;
 
 class ModelUtilTest extends AbstractUtilsTestCase
 {
@@ -40,7 +40,9 @@ class ModelUtilTest extends AbstractUtilsTestCase
             Model::class => $this->modelAdapter,
         ]);
 
-        return new ModelUtil($contaoFramework);
+        $insertTagParser = $parameters['insertTagParser'] ?? $this->createMock(InsertTagParser::class);
+
+        return new ModelUtil($contaoFramework, $insertTagParser);
     }
 
     /**

--- a/tests/Util/ModelUtilTest.php
+++ b/tests/Util/ModelUtilTest.php
@@ -40,7 +40,13 @@ class ModelUtilTest extends AbstractUtilsTestCase
             Model::class => $this->modelAdapter,
         ]);
 
-        $insertTagParser = $parameters['insertTagParser'] ?? $this->createMock(InsertTagParser::class);
+        if (!($insertTagParser = $parameters['insertTagParser'] ?? null))
+        {
+            $insertTagParser = $this->createMock(InsertTagParser::class);
+            $insertTagParser->method('replace')->willReturnCallback(function ($tag) {
+                return $tag;
+            });
+        }
 
         return new ModelUtil($contaoFramework, $insertTagParser);
     }


### PR DESCRIPTION
In Contao 4.13, Controller(...)->replaceInsertTags became deprecated.
In Contao 5, it has been removed.

According to forum members, service `Contao\CoreBundle\InsertTag\InsertTagParser` should be used instead.

https://community.contao.org/de/showthread.php?84798-replaceInsertTags-in-Contao-5