### PR TITLE
dca()->getDcaFields() move constructor call to method body

### DIFF
--- a/src/Util/DcaUtil.php
+++ b/src/Util/DcaUtil.php
@@ -136,8 +136,12 @@ class DcaUtil
      * Return a list of dca fields for given table.
      * Fields can be filtered by given options.
      */
-    public function getDcaFields(string $table, GetDcaFieldsOptions $options = new GetDcaFieldsOptions()): array
+    public function getDcaFields(string $table, ?GetDcaFieldsOptions $options = null): array
     {
+        if (null === $options) {
+            $options = new GetDcaFieldsOptions();
+        }
+
         $fields = [];
 
         $controller = $this->contaoFramework->getAdapter(Controller::class);


### PR DESCRIPTION
This eases passing as a parameter from within a nested context.

e.g.

```php
    public static function getFieldOptions(DataContainer $dc, ?GetDcaFieldsOptions $options = null)
    {
        System::getContainer()->get(Utils::class)->dca()->getDcaFields($dc->table, $options);
    }
```

This way we don't override the default options cunstructor.

Just a QoL improvement. Does not break backward compatibility.