### PR TITLE
Url Util Improvements

### DIFF
--- a/src/EntityFinder/EntityFinderHelper.php
+++ b/src/EntityFinder/EntityFinderHelper.php
@@ -17,6 +17,7 @@ use Contao\ModuleModel;
 use Contao\Validator;
 use Doctrine\DBAL\Connection;
 use HeimrichHannot\UtilsBundle\Util\Utils;
+use ValueError;
 
 class EntityFinderHelper
 {
@@ -170,7 +171,7 @@ class EntityFinderHelper
             {
                 if ($strKey === 'strTable')
                 {
-                    self::$strTable = $varValue;
+                    throw new ValueError('Cannot set strTable property non-statically');
                 }
 
                 if (isset($this->arrData[$strKey]) && $this->arrData[$strKey] === $varValue)

--- a/src/EntityFinder/EntityFinderHelper.php
+++ b/src/EntityFinder/EntityFinderHelper.php
@@ -152,12 +152,27 @@ class EntityFinderHelper
             /** @noinspection PhpMissingParentConstructorInspection */
             public function __construct(string $table, array $data = [])
             {
-                static::$strTable = $table;
+                self::$strTable = $table;
                 $this->setRow($data);
+            }
+
+            public function __get($strKey)
+            {
+                if ($strKey === 'strTable')
+                {
+                    return self::$strTable;
+                }
+
+                return parent::__get($strKey);
             }
 
             public function __set($strKey, $varValue)
             {
+                if ($strKey === 'strTable')
+                {
+                    self::$strTable = $varValue;
+                }
+
                 if (isset($this->arrData[$strKey]) && $this->arrData[$strKey] === $varValue)
                 {
                     return;

--- a/src/EntityFinder/EntityFinderHelper.php
+++ b/src/EntityFinder/EntityFinderHelper.php
@@ -149,9 +149,10 @@ class EntityFinderHelper
 
             protected $blnPreventSaving = true;
 
+            /** @noinspection PhpMissingParentConstructorInspection */
             public function __construct(string $table, array $data = [])
             {
-                $this->strTable = $table;
+                static::$strTable = $table;
                 $this->setRow($data);
             }
 

--- a/src/EntityFinder/EntityFinderHelper.php
+++ b/src/EntityFinder/EntityFinderHelper.php
@@ -147,13 +147,14 @@ class EntityFinderHelper
     private function anonymousModel(string $table, array $data): Model
     {
         return new class($table, $data) extends Model {
+            protected static $strTable;
 
             protected $blnPreventSaving = true;
 
             /** @noinspection PhpMissingParentConstructorInspection */
             public function __construct(string $table, array $data = [])
             {
-                self::$strTable = $table;
+                static::$strTable = $table;
                 $this->setRow($data);
             }
 
@@ -161,7 +162,7 @@ class EntityFinderHelper
             {
                 if ($strKey === 'strTable')
                 {
-                    return self::$strTable;
+                    return static::$strTable;
                 }
 
                 return parent::__get($strKey);

--- a/src/StaticUtil/SUtils.php
+++ b/src/StaticUtil/SUtils.php
@@ -2,23 +2,23 @@
 
 namespace HeimrichHannot\UtilsBundle\StaticUtil;
 
-class SUtils
+final class SUtils
 {
-    protected static array $instances = [];
+    private static array $instances = [];
 
     public static function array(): StaticArrayUtil
     {
-        return static::getInstance(StaticArrayUtil::class);
+        return SUtils::getInstance(StaticArrayUtil::class);
     }
 
     public static function class(): StaticClassUtil
     {
-        return static::getInstance(StaticClassUtil::class);
+        return SUtils::getInstance(StaticClassUtil::class);
     }
 
     public static function url(): StaticUrlUtil
     {
-        return static::getInstance(StaticUrlUtil::class);
+        return SUtils::getInstance(StaticUrlUtil::class);
     }
 
     /**
@@ -28,10 +28,10 @@ class SUtils
      */
     protected static function getInstance(string $class)
     {
-        if (!isset(static::$instances[$class])) {
-            static::$instances[$class] = new $class;
+        if (!isset(SUtils::$instances[$class])) {
+            SUtils::$instances[$class] = new $class;
         }
 
-        return static::$instances[$class];
+        return SUtils::$instances[$class];
     }
 }

--- a/src/StaticUtil/SUtils.php
+++ b/src/StaticUtil/SUtils.php
@@ -16,6 +16,11 @@ class SUtils
         return static::getInstance(StaticClassUtil::class);
     }
 
+    public static function url(): StaticUrlUtil
+    {
+        return static::getInstance(StaticUrlUtil::class);
+    }
+
     /**
      * @template T
      * @param class-string<T> $class

--- a/src/StaticUtil/StaticArrayUtil.php
+++ b/src/StaticUtil/StaticArrayUtil.php
@@ -9,10 +9,10 @@ class StaticArrayUtil extends AbstractStaticUtil
      * If the keys not exist, the new entry is added to the end of the array.
      * Array is passed as reference.
      *
-     * @param array        $array    Array the new entry should inserted to
-     * @param array|string $keys     The key or keys where the new entry should be added before
-     * @param string       $newKey   The key of the entry that should be added
-     * @param mixed        $newValue The value of the entry that should be added
+     * @param array        $array    The Array to modify
+     * @param array|string $keys     The key or keys before which the new entry should be added
+     * @param string       $newKey   The key of the entry added
+     * @param mixed        $newValue The value of the entry added
      */
     public static function insertBeforeKey(array &$array, array|string $keys, string $newKey, mixed $newValue): void
     {
@@ -39,9 +39,9 @@ class StaticArrayUtil extends AbstractStaticUtil
      * Insert a value into an existing array by key name.
      *
      * Additional options:
-     * - (bool) strict: Strict behavior for array search. Default false
-     * - (bool) attachMissingKey: Attach value to the end of the array if the key does not exist. Default: true
-     * - (int) offset: Add additional offset.
+     * - strict (bool):           Strict behavior for array search. (default: false)
+     * - attachMissingKey (bool): Attach value to the end of the array if the key does not exist. (default: true)
+     * - offset (int):            Add additional offset. (default: 0)
      *
      * @param array  $array   The target array
      * @param string $key     the existing target key in the array
@@ -84,11 +84,11 @@ class StaticArrayUtil extends AbstractStaticUtil
     /**
      * Removes a value from an array.
      *
-     * @return bool Returns true if the value has been found and removed, false in other cases
+     * @return bool Returns true if the value has been found and removed, false otherwise.
      */
     public static function removeValue(mixed $value, array &$array): bool
     {
-        $position = array_search($value, $array);
+        $position = \array_search($value, $array);
 
         if (false !== $position) {
             unset($array[$position]);

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -65,9 +65,9 @@ class StaticUrlUtil extends AbstractStaticUtil
             $url = isset($path) ? rtrim($url, '/') . '/' : $url;
         }
 
-        $url .= isset($path) ? ltrim($path, '/') : '';
-        $url .= isset($query) ? ($url || $queryPrefix ? '?' : '') . $query : '';
-        $url .= isset($fragment) ? ($url || $fragmentPrefix ? '#' : '') . $fragment : '';
+        $url .= empty($path) ? '' : ltrim($path, '/');
+        $url .= empty($query) ? '' : ($url || $queryPrefix ? '?' : '') . $query;
+        $url .= empty($fragment) ? '' : ($url || $fragmentPrefix ? '#' : '') . $fragment;
 
         return $url;
     }

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -33,10 +33,8 @@ class StaticUrlUtil extends AbstractStaticUtil
      * } $options   Options for URL construction.
      * @return string The reconstructed URL.
      */
-    public static function unparseUrl(
-        array $parsedUrl,
-        array $options = [],
-    ): string {
+    public static function unparseUrl(array $parsedUrl, array $options = []): string
+    {
         $suffixEmptyScheme = (bool) ($options['suffixEmptyScheme'] ?? true);
         $prefixPath        = (bool) ($options['prefixPath'] ?? true);
         $prefixQuery       = (bool) ($options['prefixQuery'] ?? true);

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace HeimrichHannot\UtilsBundle\StaticUtil;
+
+class StaticUrlUtil extends AbstractStaticUtil
+{
+    /**
+     * This method is the reverse of {@see \parse_url `parse_url(...)`} and is used to build a URL from its components.
+     *
+     * @see https://www.php.net/manual/en/function.parse-url.php
+     *
+     * @param array{
+     *     scheme?: string,
+     *     host?: string,
+     *     port?: int,
+     *     user?: string,
+     *     pass?: string,
+     *     path?: string,
+     *     query?: string,
+     *     fragment?: string,
+     * }                $parsedUrl          The parsed URL components.
+     * @param bool|null $emptySchemeSuffix  Whether to add `//` before the host if no scheme is provided. Defaults to true.
+     * @param bool|null $queryPrefix        Whether to add `?` before the query string if the URL is otherwise empty. Defaults to true.
+     * @param bool|null $fragmentPrefix     Whether to add `#` before the fragment if the URL is otherwise empty. Defaults to true.
+     * @return string
+     */
+    public static function unparseUrl(
+        array $parsedUrl,
+        ?bool $emptySchemeSuffix = null,
+        ?bool $queryPrefix = null,
+        ?bool $fragmentPrefix = null,
+    ): string {
+        $emptySchemeSuffix ??= true;
+        $queryPrefix ??= true;
+        $fragmentPrefix ??= true;
+
+        if (empty($parsedUrl))
+        {
+            return '';
+        }
+
+        $scheme = $parsedUrl['scheme'] ?? null;
+        $host = $parsedUrl['host'] ?? null;
+        $port = $parsedUrl['port'] ?? null;
+        $user = $parsedUrl['user'] ?? null;
+        $pass = $parsedUrl['pass'] ?? null;
+        $path = $parsedUrl['path'] ?? null;
+        $query = $parsedUrl['query'] ?? null;
+        $fragment = $parsedUrl['fragment'] ?? null;
+
+        $url = '';
+
+        if ($host)
+        {
+            if (isset($scheme)) {
+                $url .= $scheme . '://';
+            } elseif ($emptySchemeSuffix) {
+                $url .= '//';
+            }
+
+            $url .= isset($user) ? $user . (isset($pass) ? ':' . $pass : '') . '@' : '';
+            $url .= $host;
+            $url .= isset($port) ? ':' . $port : '';
+
+            $url = isset($path) ? rtrim($url, '/') . '/' : $url;
+        }
+
+        $url .= isset($path) ? ltrim($path, '/') : '';
+        $url .= isset($query) ? ($url || $queryPrefix ? '?' : '') . $query : '';
+        $url .= isset($fragment) ? ($url || $fragmentPrefix ? '#' : '') . $fragment : '';
+
+        return $url;
+    }
+}

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -8,10 +8,10 @@ class StaticUrlUtil extends AbstractStaticUtil
      * This method is the reverse of {@see \parse_url `parse_url(...)`} and is used to build a URL from its components.
      *
      * Options:
-     * - suffixEmptyScheme (bool): Whether to add `//` before the host if no scheme is provided. (default: true)
-     * - prefixPath (bool):        Whether to add `/` before the path if the URL is otherwise empty. (default: true)
-     * - prefixQuery (bool):       Whether to add `?` before the query string if the URL is otherwise empty. (default: true)
-     * - prefixFragment (bool):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: true)
+     * - `suffixEmptyScheme` (`bool`): Whether to add `//` before the host if no scheme is provided. (default: `true`)
+     * - `prefixPath` (`bool`):        Whether to add `/` before the path if the URL is otherwise empty. (default: `true`)
+     * - `prefixQuery` (`bool`):       Whether to add `?` before the query string if the URL is otherwise empty. (default: `true`)
+     * - `prefixFragment` (`bool`):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: `true`)
      *
      * @see https://www.php.net/manual/en/function.parse-url.php
      *

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -9,11 +9,11 @@ class StaticUrlUtil extends AbstractStaticUtil
      *
      * @see https://www.php.net/manual/en/function.parse-url.php
      *
-     *  Options:
-     *  - suffixEmptyScheme (bool): Whether to add `//` before the host if no scheme is provided. (default: true)
-     *  - prefixPath (bool):        Whether to add `/` before the path if the URL is otherwise empty. (default: true)
-     *  - prefixQuery (bool):       Whether to add `?` before the query string if the URL is otherwise empty. (default: true)
-     *  - prefixFragment (bool):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: true)
+     * Options:
+     * - suffixEmptyScheme (bool): Whether to add `//` before the host if no scheme is provided. (default: true)
+     * - prefixPath (bool):        Whether to add `/` before the path if the URL is otherwise empty. (default: true)
+     * - prefixQuery (bool):       Whether to add `?` before the query string if the URL is otherwise empty. (default: true)
+     * - prefixFragment (bool):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: true)
      *
      * @param array{
      *     scheme?: string,

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -7,13 +7,13 @@ class StaticUrlUtil extends AbstractStaticUtil
     /**
      * This method is the reverse of {@see \parse_url `parse_url(...)`} and is used to build a URL from its components.
      *
-     * @see https://www.php.net/manual/en/function.parse-url.php
-     *
      * Options:
      * - suffixEmptyScheme (bool): Whether to add `//` before the host if no scheme is provided. (default: true)
      * - prefixPath (bool):        Whether to add `/` before the path if the URL is otherwise empty. (default: true)
      * - prefixQuery (bool):       Whether to add `?` before the query string if the URL is otherwise empty. (default: true)
      * - prefixFragment (bool):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: true)
+     *
+     * @see https://www.php.net/manual/en/function.parse-url.php
      *
      * @param array{
      *     scheme?: string,
@@ -25,12 +25,14 @@ class StaticUrlUtil extends AbstractStaticUtil
      *     query?: string,
      *     fragment?: string,
      * } $parsedUrl The parsed URL components.
+     *
      * @param array{
      *     suffixEmptyScheme?: bool,
      *     prefixPath?: bool,
      *     prefixQuery?: bool,
      *     prefixFragment?: bool,
      * } $options   Options for URL construction.
+     *
      * @return string The reconstructed URL.
      */
     public static function unparseUrl(array $parsedUrl, array $options = []): string

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -9,6 +9,12 @@ class StaticUrlUtil extends AbstractStaticUtil
      *
      * @see https://www.php.net/manual/en/function.parse-url.php
      *
+     *  Options:
+     *  - suffixEmptyScheme (bool): Whether to add `//` before the host if no scheme is provided. (default: true)
+     *  - prefixPath (bool):        Whether to add `/` before the path if the URL is otherwise empty. (default: true)
+     *  - prefixQuery (bool):       Whether to add `?` before the query string if the URL is otherwise empty. (default: true)
+     *  - prefixFragment (bool):    Whether to add `#` before the fragment if the URL is otherwise empty. (default: true)
+     *
      * @param array{
      *     scheme?: string,
      *     host?: string,
@@ -18,37 +24,36 @@ class StaticUrlUtil extends AbstractStaticUtil
      *     path?: string,
      *     query?: string,
      *     fragment?: string,
-     * }                $parsedUrl         The parsed URL components.
-     * @param bool|null $suffixEmptyScheme Whether to add `//` before the host if no scheme is provided. Defaults to true.
-     * @param bool|null $prefixPath        Whether to add `/` before the path if the URL is otherwise empty. Defaults to true.
-     * @param bool|null $prefixQuery       Whether to add `?` before the query string if the URL is otherwise empty. Defaults to true.
-     * @param bool|null $prefixFragment    Whether to add `#` before the fragment if the URL is otherwise empty. Defaults to true.
-     * @return string
+     * } $parsedUrl The parsed URL components.
+     * @param array{
+     *     suffixEmptyScheme?: bool,
+     *     prefixPath?: bool,
+     *     prefixQuery?: bool,
+     *     prefixFragment?: bool,
+     * } $options   Options for URL construction.
+     * @return string The reconstructed URL.
      */
     public static function unparseUrl(
         array $parsedUrl,
-        ?bool $suffixEmptyScheme = null,
-        ?bool $prefixPath = null,
-        ?bool $prefixQuery = null,
-        ?bool $prefixFragment = null,
+        array $options = [],
     ): string {
-        $suffixEmptyScheme ??= true;
-        $prefixPath ??= true;
-        $prefixQuery ??= true;
-        $prefixFragment ??= true;
+        $suffixEmptyScheme = (bool) ($options['suffixEmptyScheme'] ?? true);
+        $prefixPath        = (bool) ($options['prefixPath'] ?? true);
+        $prefixQuery       = (bool) ($options['prefixQuery'] ?? true);
+        $prefixFragment    = (bool) ($options['prefixFragment'] ?? true);
 
         if (empty($parsedUrl))
         {
             return '';
         }
 
-        $scheme = $parsedUrl['scheme'] ?? null;
-        $host = $parsedUrl['host'] ?? null;
-        $port = $parsedUrl['port'] ?? null;
-        $user = $parsedUrl['user'] ?? null;
-        $pass = $parsedUrl['pass'] ?? null;
-        $path = $parsedUrl['path'] ?? null;
-        $query = $parsedUrl['query'] ?? null;
+        $scheme   = $parsedUrl['scheme'] ?? null;
+        $host     = $parsedUrl['host'] ?? null;
+        $port     = $parsedUrl['port'] ?? null;
+        $user     = $parsedUrl['user'] ?? null;
+        $pass     = $parsedUrl['pass'] ?? null;
+        $path     = $parsedUrl['path'] ?? null;
+        $query    = $parsedUrl['query'] ?? null;
         $fragment = $parsedUrl['fragment'] ?? null;
 
         $url = '';

--- a/src/StaticUtil/StaticUrlUtil.php
+++ b/src/StaticUtil/StaticUrlUtil.php
@@ -18,21 +18,24 @@ class StaticUrlUtil extends AbstractStaticUtil
      *     path?: string,
      *     query?: string,
      *     fragment?: string,
-     * }                $parsedUrl          The parsed URL components.
-     * @param bool|null $emptySchemeSuffix  Whether to add `//` before the host if no scheme is provided. Defaults to true.
-     * @param bool|null $queryPrefix        Whether to add `?` before the query string if the URL is otherwise empty. Defaults to true.
-     * @param bool|null $fragmentPrefix     Whether to add `#` before the fragment if the URL is otherwise empty. Defaults to true.
+     * }                $parsedUrl         The parsed URL components.
+     * @param bool|null $suffixEmptyScheme Whether to add `//` before the host if no scheme is provided. Defaults to true.
+     * @param bool|null $prefixPath        Whether to add `/` before the path if the URL is otherwise empty. Defaults to true.
+     * @param bool|null $prefixQuery       Whether to add `?` before the query string if the URL is otherwise empty. Defaults to true.
+     * @param bool|null $prefixFragment    Whether to add `#` before the fragment if the URL is otherwise empty. Defaults to true.
      * @return string
      */
     public static function unparseUrl(
         array $parsedUrl,
-        ?bool $emptySchemeSuffix = null,
-        ?bool $queryPrefix = null,
-        ?bool $fragmentPrefix = null,
+        ?bool $suffixEmptyScheme = null,
+        ?bool $prefixPath = null,
+        ?bool $prefixQuery = null,
+        ?bool $prefixFragment = null,
     ): string {
-        $emptySchemeSuffix ??= true;
-        $queryPrefix ??= true;
-        $fragmentPrefix ??= true;
+        $suffixEmptyScheme ??= true;
+        $prefixPath ??= true;
+        $prefixQuery ??= true;
+        $prefixFragment ??= true;
 
         if (empty($parsedUrl))
         {
@@ -54,7 +57,7 @@ class StaticUrlUtil extends AbstractStaticUtil
         {
             if (isset($scheme)) {
                 $url .= $scheme . '://';
-            } elseif ($emptySchemeSuffix) {
+            } elseif ($suffixEmptyScheme) {
                 $url .= '//';
             }
 
@@ -62,12 +65,12 @@ class StaticUrlUtil extends AbstractStaticUtil
             $url .= $host;
             $url .= isset($port) ? ':' . $port : '';
 
-            $url = isset($path) ? rtrim($url, '/') . '/' : $url;
+            $url = rtrim($url, '/');
         }
 
-        $url .= empty($path) ? '' : ltrim($path, '/');
-        $url .= empty($query) ? '' : ($url || $queryPrefix ? '?' : '') . $query;
-        $url .= empty($fragment) ? '' : ($url || $fragmentPrefix ? '#' : '') . $fragment;
+        $url .= empty($path) ? '' : ($url || $prefixPath ? '/' : '') . ltrim($path, '/');
+        $url .= empty($query) ? '' : ($url || $prefixQuery ? '?' : '') . $query;
+        $url .= empty($fragment) ? '' : ($url || $prefixFragment ? '#' : '') . $fragment;
 
         return $url;
     }

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -120,7 +120,7 @@ class UrlUtil
 
         unset($urlParts['schema'], $urlParts['user'], $urlParts['pass'], $urlParts['host'], $urlParts['port']);
 
-        return SUtils::url()->unparseUrl($urlParts, prefixPath: (bool) $options['removeLeadingSlash']);
+        return SUtils::url()->unparseUrl($urlParts, prefixPath: !$options['removeLeadingSlash']);
     }
 
     private function getUrlOrDefault(?string $url = null): string

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -87,7 +87,7 @@ class UrlUtil
             $newKeyValuePair = $parameter;
         }
 
-        $parsedUrl['query'] = \http_build_query(\array_merge($keyValuePairs ?? [], $newKeyValuePair ?? []));
+        $parsedUrl['query'] = \http_build_query(\array_merge($keyValuePairs ?? [], $newKeyValuePair));
 
         return SUtils::url()->unparseUrl($parsedUrl);
     }

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class UrlUtil
 {
-    public function __construct(private RequestStack $requestStack) {}
+    public function __construct(private readonly RequestStack $requestStack) {}
 
     /**
      * Remove query parameters (GET parameter) from a URL.

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -12,7 +12,7 @@ use HeimrichHannot\UtilsBundle\Exception\InvalidUrlException;
 use HeimrichHannot\UtilsBundle\StaticUtil\SUtils;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-readonly class UrlUtil
+class UrlUtil
 {
     public function __construct(private RequestStack $requestStack) {}
 

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -118,13 +118,9 @@ class UrlUtil
             throw new InvalidUrlException('The URL provided is invalid and could not be parsed.');
         }
 
-        unset($urlParts['schema'], $urlParts['host'], $urlParts['port'], $urlParts['user'], $urlParts['pass']);
+        unset($urlParts['schema'], $urlParts['user'], $urlParts['pass'], $urlParts['host'], $urlParts['port']);
 
-        if (isset($urlParts['path']) && $options['removeLeadingSlash']) {
-            $urlParts['path'] = \ltrim($urlParts['path'], '/');
-        }
-
-        return SUtils::url()->unparseUrl($urlParts);
+        return SUtils::url()->unparseUrl($urlParts, prefixPath: (bool) $options['removeLeadingSlash']);
     }
 
     private function getUrlOrDefault(?string $url = null): string

--- a/src/Util/UrlUtil.php
+++ b/src/Util/UrlUtil.php
@@ -107,10 +107,6 @@ class UrlUtil
      */
     public function makeUrlRelative(string $url, array $options = []): string
     {
-        $options = array_merge([
-            'removeLeadingSlash' => false,
-        ], $options);
-
         /** @var array|false $urlParts */
         $urlParts = \parse_url($url);
 
@@ -120,7 +116,7 @@ class UrlUtil
 
         unset($urlParts['schema'], $urlParts['user'], $urlParts['pass'], $urlParts['host'], $urlParts['port']);
 
-        return SUtils::url()->unparseUrl($urlParts, prefixPath: !$options['removeLeadingSlash']);
+        return SUtils::url()->unparseUrl($urlParts, ['prefixPath' => !($options['removeLeadingSlash'] ?? false)]);
     }
 
     private function getUrlOrDefault(?string $url = null): string

--- a/tests/StaticUtil/StaticUrlUtilTest.php
+++ b/tests/StaticUtil/StaticUrlUtilTest.php
@@ -16,22 +16,21 @@ class StaticUrlUtilTest extends ContaoTestCase
         $this->assertEquals(
             '//operator:secret@example.com:1234',
             StaticUrlUtil::unparseUrl(['user' => 'operator', 'pass' => 'secret', 'host' => 'example.com', 'port' => '1234'],
-                suffixEmptyScheme: true),
+                ['suffixEmptyScheme' => true]),
         );
         $this->assertEquals('example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234'],
-            suffixEmptyScheme: false));
+            ['suffixEmptyScheme' => false]));
 
         $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar']));
-        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], prefixQuery: true));
-        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], prefixQuery: false));
+        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], ['prefixQuery' => true]));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], ['prefixQuery' => false]));
 
         $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar']));
-        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], prefixFragment: true));
-        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], prefixFragment: false));
+        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], ['prefixFragment' => true]));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], ['prefixFragment' => false]));
 
         $this->assertEquals('foo=bar#baz', StaticUrlUtil::unparseUrl(['query' => 'foo=bar', 'fragment' => 'baz'],
-            prefixQuery: false,
-            prefixFragment: false));
+            ['prefixQuery' => false, 'prefixFragment' => false]));
 
         $url = 'wss://user:pass@example.com:1234?foo=bar#baz';
         $this->assertEquals($url, StaticUrlUtil::unparseUrl(\parse_url($url)));

--- a/tests/StaticUtil/StaticUrlUtilTest.php
+++ b/tests/StaticUtil/StaticUrlUtilTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace StaticUtil;
+
+use Contao\TestCase\ContaoTestCase;
+use HeimrichHannot\UtilsBundle\StaticUtil\StaticUrlUtil;
+
+class StaticUrlUtilTest extends ContaoTestCase
+{
+    public function testUnparseUrl()
+    {
+        $this->assertEmpty(StaticUrlUtil::unparseUrl([]));
+        $this->assertEmpty(StaticUrlUtil::unparseUrl(['port' => '1234']));
+
+        $this->assertEquals('//example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234']));
+        $this->assertEquals(
+            '//operator:secret@example.com:1234',
+            StaticUrlUtil::unparseUrl(['user' => 'operator', 'pass' => 'secret', 'host' => 'example.com', 'port' => '1234'], emptySchemeSuffix: true),
+        );
+        $this->assertEquals('example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234'], emptySchemeSuffix: false));
+
+        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar']));
+        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], queryPrefix: true));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], queryPrefix: false));
+
+        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar']));
+        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], fragmentPrefix: true));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], fragmentPrefix: false));
+
+        $this->assertEquals('foo=bar#baz', StaticUrlUtil::unparseUrl(['query' => 'foo=bar', 'fragment' => 'baz'], queryPrefix: false, fragmentPrefix: false));
+
+        $url = 'wss://user:pass@example.com:1234?foo=bar#baz';
+        $this->assertEquals($url, StaticUrlUtil::unparseUrl(\parse_url($url)));
+    }
+}

--- a/tests/StaticUtil/StaticUrlUtilTest.php
+++ b/tests/StaticUtil/StaticUrlUtilTest.php
@@ -15,19 +15,23 @@ class StaticUrlUtilTest extends ContaoTestCase
         $this->assertEquals('//example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234']));
         $this->assertEquals(
             '//operator:secret@example.com:1234',
-            StaticUrlUtil::unparseUrl(['user' => 'operator', 'pass' => 'secret', 'host' => 'example.com', 'port' => '1234'], emptySchemeSuffix: true),
+            StaticUrlUtil::unparseUrl(['user' => 'operator', 'pass' => 'secret', 'host' => 'example.com', 'port' => '1234'],
+                suffixEmptyScheme: true),
         );
-        $this->assertEquals('example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234'], emptySchemeSuffix: false));
+        $this->assertEquals('example.com:1234', StaticUrlUtil::unparseUrl(['host' => 'example.com', 'port' => '1234'],
+            suffixEmptyScheme: false));
 
         $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar']));
-        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], queryPrefix: true));
-        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], queryPrefix: false));
+        $this->assertEquals('?foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], prefixQuery: true));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['query' => 'foo=bar'], prefixQuery: false));
 
         $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar']));
-        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], fragmentPrefix: true));
-        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], fragmentPrefix: false));
+        $this->assertEquals('#foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], prefixFragment: true));
+        $this->assertEquals('foo=bar', StaticUrlUtil::unparseUrl(['fragment' => 'foo=bar'], prefixFragment: false));
 
-        $this->assertEquals('foo=bar#baz', StaticUrlUtil::unparseUrl(['query' => 'foo=bar', 'fragment' => 'baz'], queryPrefix: false, fragmentPrefix: false));
+        $this->assertEquals('foo=bar#baz', StaticUrlUtil::unparseUrl(['query' => 'foo=bar', 'fragment' => 'baz'],
+            prefixQuery: false,
+            prefixFragment: false));
 
         $url = 'wss://user:pass@example.com:1234?foo=bar#baz';
         $this->assertEquals($url, StaticUrlUtil::unparseUrl(\parse_url($url)));

--- a/tests/Util/UrlUtilTest.php
+++ b/tests/Util/UrlUtilTest.php
@@ -29,6 +29,8 @@ class UrlUtilTest extends ContaoTestCase
         $this->assertSame($instance->addQueryStringParameterToUrl(['foo' => 'bar'], $url), $url . '?foo=bar');
         $this->assertSame($instance->addQueryStringParameterToUrl(['foo' => 'bar'], $url . '?foo=baz'), $url . '?foo=bar');
         $this->assertSame($instance->addQueryStringParameterToUrl(['foo' => 'bar', 'spam' => 'ham'], $url . '?foo=baz'), $url . '?foo=bar&spam=ham');
+
+        $this->assertSame($instance->addQueryStringParameterToUrl(['foo' => 'bar', 'spam' => 'ham'], ''), '?foo=bar&spam=ham');
     }
 
     public function testRemoveQueryStringParameterFromUrl()


### PR DESCRIPTION
- added static UrlUtil with unparseUrl method (opposite of \parse_url for which there is no stdlib equivalent)
- added tests for the static util
- refactored the regular UrlUtil

To improve the API, the url params of `UrlUtil::removeQueryStringParameterFromUrl(...)` and `UrlUtil::addQueryStringParameterToUrl(...)` were changed to be nullable; if null, the current request will be used. Previosly, the current request was used on any falsy value of $url. This is not the desired behaviour. Providing any string, including the empty string, should be treated as an intended URL/URI and should not be overriden by defaults. This change should not break BC in 99% of use cases. IF IT DOES it is most likely bugged behaviour anyway.